### PR TITLE
chore:requirements수정-macOS충돌 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# 시스템 패키지 업데이트 및 필요한 패키지 설치
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python 의존성 설치
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 애플리케이션 코드 복사
+COPY . .
+
+# Streamlit 포트 노출
+EXPOSE 8501
+
+# Streamlit 실행
+CMD ["streamlit", "run", "app.py", "--server.port=8501", "--server.address=0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,21 @@ services:
       timeout: 10s
       retries: 3
 
+  # Python 3.12 애플리케이션
+  app:
+    build: .
+    container_name: SKN18-3rd-app
+    ports:
+      - "8501:8501" # Streamlit 기본 포트
+    environment:
+      - DATABASE_URL=postgresql://postgres:post1234@postgres:5432/skn_project
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - SKN3rd_network
+    restart: unless-stopped
+
 # 볼륨 정의
 volumes:
   postgres_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
-# DART API 다운로더 필수 패키지
 
+# Python 3.12 고정
 # HTTP 요청 라이브러리
-requests==2.31.0
+requests>=2.28.0
 
 # 환경변수 관리
-python-dotenv==1.0.0
+python-dotenv>=0.19.0
 
 # Streamlit 패키지
 streamlit>=1.27.0
 
-# PostgreSQL 패키지
-psycopg2-binary==2.9.9
-sqlalchemy==2.0.23
+# PostgreSQL 패키지 (가벼운 버전)
+psycopg2-binary>=2.9.0
+sqlalchemy>=1.4.0
 
-# 벡터 데이터베이스 및 임베딩
-pgvector==0.2.4
-sentence-transformers==2.2.2
-numpy==1.24.3
+# 벡터 데이터베이스 및 임베딩 (가벼운 버전)
+pgvector>=0.2.0
+sentence-transformers>=2.0.0
+numpy>=1.21.0
 
-# 데이터 처리
-pandas==2.0.3
+# 데이터 처리 (가벼운 버전)
+pandas>=1.5.0


### PR DESCRIPTION
1. Python 3.12로 가상환경 재설치 필요. 
