### PR TITLE
chore:requirements수정-macOS충돌 해결

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,25 @@
-# DART API 다운로더 필수 패키지
 
+# Python 3.12 고정
 # HTTP 요청 라이브러리
-requests==2.31.0
+requests>=2.28.0
 
 # 환경변수 관리
-python-dotenv==1.0.0
+python-dotenv>=0.19.0
 
 # Streamlit 패키지
 streamlit>=1.27.0
 
-# PostgreSQL 패키지
-psycopg2-binary==2.9.9
-sqlalchemy==2.0.23
+# PostgreSQL 패키지 (가벼운 버전)
+psycopg2-binary>=2.9.0
+sqlalchemy>=1.4.0
 
-# 벡터 데이터베이스 및 임베딩
-pgvector==0.2.4
-sentence-transformers==2.2.2
-numpy==1.24.3
+# 벡터 데이터베이스 및 임베딩 (가벼운 버전)
+pgvector>=0.2.0
+sentence-transformers>=2.0.0
+numpy>=1.21.0
 
-# 데이터 처리
-pandas==2.0.3
+# 데이터 처리 (가벼운 버전)
+pandas>=1.5.0
+
+# XML 파싱
+lxml>=4.9.0


### PR DESCRIPTION
Python 3.12로 가상환경 재설치 필요.